### PR TITLE
Some Improvements to the Gitian Verification Script

### DIFF
--- a/verify-merge.py
+++ b/verify-merge.py
@@ -3,26 +3,34 @@ import argparse
 import os
 import subprocess
 import glob
+import sys
 
 GIT = os.getenv('GIT','git')
 GPG = os.getenv('GPG','gpg')
 
 def verify():
     global args, workdir
-    os.chdir('gitian-pubkeys')
-    print('Importing pubkeys...')
-    keys = [f for f in glob.glob("*.asc", recursive=True)]
-    for key in keys:
-        subprocess.check_call([GPG, '--import', key])
-    print('Refreshing pubkeys...')
-    subprocess.check_call([GPG, '--refresh'])
-    os.chdir('../../gitian-builder')
-    print('\nVerifying '+args.version+' Linux\n')
-    subprocess.check_call(['bin/gverify', '-v', '-d', '../gitian.sigs/', '-r', args.version+'-linux', '../monero/contrib/gitian/gitian-linux.yml'])
-    print('\nVerifying '+args.version+' Windows\n')
-    subprocess.check_call(['bin/gverify', '-v', '-d', '../gitian.sigs/', '-r', args.version+'-win', '../monero/contrib/gitian/gitian-win.yml'])
-    print('\nVerifying '+args.version+' MacOS\n')
-    subprocess.check_call(['bin/gverify', '-v', '-d', '../gitian.sigs/', '-r', args.version+'-osx', '../monero/contrib/gitian/gitian-osx.yml'])
+    if args.import_keys:
+        os.chdir('gitian-pubkeys')
+        print('Importing pubkeys...')
+        keys = [f for f in glob.glob("*.asc", recursive=True)]
+        for key in keys:
+            subprocess.check_call([GPG, '--import', key])
+        os.chdir('../')
+    if args.refresh_keys:
+        print('Refreshing pubkeys...')
+        subprocess.check_call([GPG, '--refresh'])
+    if not os.path.isdir(args.gitian_builder_dir):
+        sys.stderr.write('Please clone the gitian-builder repository from github.com/devrandom/gitian-builder to the directory containing the gitian.sigs repository.\nIf you already have the gitian.sigs directory cloned, but under another name or path, use --gitian-builder-dir to pass its absolute directory path to the script.\n')
+        sys.exit(1)
+    if not os.path.isdir(args.monero_dir):
+        sys.stderr.write('Please clone the monero repository from github.com/monero-project/monero to the directory containing the gitian.sigs repository.\nIf you already have the monero repository cloned, but under another name or path, use --monero-dir to pass its absolute directory path to the script.\n')
+        sys.exit(1)
+    os.chdir(args.gitian_builder_dir)
+    for os_label, os_id in [("Linux","linux"), ("Windows","win"), ("MacOS","osx")]:
+        if os.path.isdir(workdir + '/' + args.version + '-' + os_id):
+            print('\nVerifying ' + args.version + ' ' + os_label)
+            subprocess.check_call(['bin/gverify', '-v', '-d', workdir, '-r', args.version + '-' + os_id, args.monero_dir + '/contrib/gitian/gitian-' + os_id + '.yml'])
     os.chdir(workdir)
 
 def main():
@@ -30,14 +38,19 @@ def main():
     global args, workdir
     parser = argparse.ArgumentParser(usage='%(prog)s [options] version', description='Use this script before merging a pull request to the gitian.sigs repository and to verify the signature of existing gitian assert files and gitian assert files in specific pull requests')
     parser.add_argument('-p', '--pull_id', dest='pull_id', help='Github Pull request id to check')
+    parser.add_argument('--monero-dir', dest='monero_dir', default='../monero', help='System Path to the monero repository, e.g. /home/user/monero')
+    parser.add_argument('--gitiian-builder-dir', dest='gitian_builder_dir', default='../gitian-builder', help='System Path to the gitian-builder repository, e.g. /home/user/gitian-builder')
     parser.add_argument('-r', '--remote', dest='remote', default='upstream', help='git remote repository')
-    parser.add_argument('-t', '--target_branch', dest='target_branch', default='master', help='Remote repository merge into branch')
+    parser.add_argument('-t', '--target-branch', dest='target_branch', default='master', help='Remote repository merge into branch')
     parser.add_argument('-m', '--merge', action='store_true', dest='merge', help='Merge the given pull request id')
+    parser.add_argument('-k', '--refresh-keys', action='store_true', dest='refresh_keys', help='refresh all pgp public keys that are currently in the gpg keyring.')
+    parser.add_argument('-i', '--import-keys', action='store_true', dest='import_keys', help='import all public keys in the gitian-pubkeys directory to the gpg keyring.')
     parser.add_argument('-o', '--no-verify', action='store_true', dest='no_verify', help='Do not run any signature verification')
     parser.add_argument('-n', '--name', dest='name', help='username for pgp key verification')
     parser.add_argument('version', help='Version number, commit, or branch to build.')
 
     args = parser.parse_args()
+
     workdir = os.getcwd()
     if args.pull_id != None:
         # Get branch from remote pull request and compare


### PR DESCRIPTION
Keys are no longer imported automatically, use `--import-keys` as an argument to import all public keys in the `gitian-pubkeys` directory.

Keys are no longer refreshed automatically, use `--refresh-keys` as an argument to refresh all public keys in the gpg keyring from the sks server.

The verification step now uses the current working directory instead of a hardcoded name in case the user renamed the gitian.sigs.

The verification can be done for singular, or just a subset, of the available operating systems by passing the `--os` flag. For example `--os=wl` to just check the signatures of windows and linux builds.