### PR TITLE
Add travis config to check sigs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+
+python:
+  - "3.7.0"
+
+script:
+  - python ./verify-merge.py --import-keys


### PR DESCRIPTION
This adds basic travis configuration to simply check all gpg signatures for all assert files.

You can see an example here (green checkmark) for this commit:
https://github.com/jonathancross/monero-gitian.sigs/commit/2135fbba51183e5b4cb275f2314a3ef8ff702cff

Direct link to travis build results:
https://github.com/jonathancross/monero-gitian.sigs/runs/306100574

### Is travis already setup?

In order to have this work on the `monero-project/gitian.sigs` repo, the owner will need to have travis setup https://travis-ci.org (free for Open Source projects).  It seems travis is working for the monero daemon repo, so may _just work_ here if the whole `monero-project` user is already setup.

Thoughts / concerns?