### PR TITLE
Simplify and improve verify-merge.py

### DIFF
--- a/verify-merge.py
+++ b/verify-merge.py
@@ -20,34 +20,36 @@ def verify():
     if args.refresh_keys:
         print('Refreshing pubkeys...')
         subprocess.check_call([GPG, '--refresh'])
-    if not os.path.isdir(args.gitian_builder_dir):
-        sys.stderr.write('Please clone the gitian-builder repository from github.com/devrandom/gitian-builder to the directory containing the gitian.sigs repository.\nIf you already have the gitian.sigs directory cloned, but under another name or path, use --gitian-builder-dir to pass its absolute directory path to the script.\n')
-        sys.exit(1)
-    if not os.path.isdir(args.monero_dir):
-        sys.stderr.write('Please clone the monero repository from github.com/monero-project/monero to the directory containing the gitian.sigs repository.\nIf you already have the monero repository cloned, but under another name or path, use --monero-dir to pass its absolute directory path to the script.\n')
-        sys.exit(1)
-    os.chdir(args.gitian_builder_dir)
-    for os_label, os_id in [("Linux","linux"), ("Windows","win"), ("MacOS","osx"), ("Android", "android")]:
-        if os.path.isdir(workdir + '/' + args.version + '-' + os_id):
-            print('\nVerifying ' + args.version + ' ' + os_label)
-            subprocess.check_call(['bin/gverify', '-v', '-d', workdir, '-r', args.version + '-' + os_id, args.monero_dir + '/contrib/gitian/gitian-' + os_id + '.yml'])
+    print('Verifying signatures:')
+    is_verification_error = False
+    ver_pattern = args.version if args.version else 'v0*'
+    for sig_file in sorted(glob.glob(ver_pattern + '-*/*/*.sig', recursive=False)):
+        print(' - ' + '{message: <{fill}}'.format(message=sig_file, fill='72'), end='')
+        result = subprocess.run([GPG, '--verify', sig_file], capture_output=True, encoding='utf-8')
+        if result.returncode != 0:
+            is_verification_error = True
+            print('\n')
+            sys.stderr.write('ERROR:\n' + result.stderr + '-' * 80 + '\n')
+        else:
+            print(' [OK]')
+    if is_verification_error:
+        sys.stderr.write('ERROR: One or more signatures failed verification.\n')
+        exit(1)
+
     os.chdir(workdir)
 
 def main():
     host_repo = "git@github.com/monero-project/gitian.sigs"
     global args, workdir
-    parser = argparse.ArgumentParser(usage='%(prog)s [options] version', description='Use this script before merging a pull request to the gitian.sigs repository and to verify the signature of existing gitian assert files and gitian assert files in specific pull requests')
+    parser = argparse.ArgumentParser(usage='%(prog)s [options]', description='Use this script to verify the signatures of existing gitian assert files and / or assert files in a specific pull request.')
     parser.add_argument('-p', '--pull_id', dest='pull_id', help='Github Pull request id to check')
-    parser.add_argument('--monero-dir', dest='monero_dir', default='../monero', help='System Path to the monero repository, e.g. /home/user/monero')
-    parser.add_argument('--gitian-builder-dir', dest='gitian_builder_dir', default='../gitian-builder', help='System Path to the gitian-builder repository, e.g. /home/user/gitian-builder')
     parser.add_argument('-r', '--remote', dest='remote', default='upstream', help='git remote repository')
     parser.add_argument('-t', '--target-branch', dest='target_branch', default='master', help='Remote repository merge into branch')
     parser.add_argument('-m', '--merge', action='store_true', dest='merge', help='Merge the given pull request id')
     parser.add_argument('-k', '--refresh-keys', action='store_true', dest='refresh_keys', help='refresh all pgp public keys that are currently in the gpg keyring.')
     parser.add_argument('-i', '--import-keys', action='store_true', dest='import_keys', help='import all public keys in the gitian-pubkeys directory to the gpg keyring.')
     parser.add_argument('-o', '--no-verify', action='store_true', dest='no_verify', help='Do not run any signature verification')
-    parser.add_argument('-n', '--name', dest='name', help='username for pgp key verification')
-    parser.add_argument('version', help='Version number, commit, or branch to build.')
+    parser.add_argument('-v', '--version', dest='version', help='Version number of sigs to be verified (defaults to all versions if not specified).')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
1. Remove dependencies on `monero` and  `gitian-builder` repos.
2. Make `version` optional.
3. By default, `--version` will default to checking all signatures found.
4. Cleanup output so errors stand out better.
5. <s>Disable</s> Removed unused `--name` parameter for now.

Example of invalid sig file for v0.14.1.2:
```
./verify-merge.py 
Verifying signatures:
 - v0.14.1.0-linux/TheCharlatan/monero-linux-0.14-build.assert.sig          [OK]
 - v0.14.1.0-linux/dikdust/monero-linux-0.14-build.assert.sig               [OK]
 - v0.14.1.0-linux/jonathancross/monero-linux-0.14-build.assert.sig         [OK]
 - v0.14.1.0-osx/TheCharlatan/monero-osx-0.14-build.assert.sig              [OK]
 - v0.14.1.0-osx/jonathancross/monero-osx-0.14-build.assert.sig             [OK]
 - v0.14.1.0-win/TheCharlatan/monero-win-0.14-build.assert.sig              [OK]
 - v0.14.1.0-win/dikdust/monero-win-0.14-build.assert.sig                   [OK]
 - v0.14.1.0-win/jonathancross/monero-win-0.14-build.assert.sig             [OK]
 - v0.14.1.1-linux/TheCharlatan/monero-linux-0.14-build.assert.sig          [OK]
 - v0.14.1.1-linux/dikdust/monero-linux-0.14-build.assert.sig               [OK]
 - v0.14.1.1-linux/jonathancross/monero-linux-0.14-build.assert.sig         [OK]
 - v0.14.1.1-osx/TheCharlatan/monero-osx-0.14-build.assert.sig              [OK]
 - v0.14.1.1-osx/jonathancross/monero-osx-0.14-build.assert.sig             [OK]
 - v0.14.1.1-win/TheCharlatan/monero-win-0.14-build.assert.sig              [OK]
 - v0.14.1.1-win/dikdust/monero-win-0.14-build.assert.sig                   [OK]
 - v0.14.1.1-win/jonathancross/monero-win-0.14-build.assert.sig             [OK]
 - v0.14.1.2-linux/TheCharlatan/monero-BROKEN-0.14-build.assert.sig        

ERROR:
gpg: verify signatures failed: Unknown system error
--------------------------------------------------------------------------------
 - v0.14.1.2-linux/TheCharlatan/monero-linux-0.14-build.assert.sig          [OK]
 - v0.14.1.2-linux/dikdust/monero-linux-0.14-build.assert.sig               [OK]
 - v0.14.1.2-linux/iDunk/monero-linux-0.14-build.assert.sig                 [OK]
 - v0.14.1.2-linux/jonathancross/monero-linux-0.14-build.assert.sig         [OK]
 - v0.14.1.2-osx/TheCharlatan/monero-osx-0.14-build.assert.sig              [OK]
 - v0.14.1.2-osx/iDunk/monero-osx-0.14-build.assert.sig                     [OK]
 - v0.14.1.2-osx/jonathancross/monero-osx-0.14-build.assert.sig             [OK]
 - v0.14.1.2-win/TheCharlatan/monero-win-0.14-build.assert.sig              [OK]
 - v0.14.1.2-win/dikdust/monero-win-0.14-build.assert.sig                   [OK]
 - v0.14.1.2-win/iDunk/monero-win-0.14-build.assert.sig                     [OK]
 - v0.14.1.2-win/jonathancross/monero-win-0.14-build.assert.sig             [OK]
 - v0.15.0.0-android/TheCharlatan/monero-android-0.15-build.assert.sig      [OK]
 - v0.15.0.0-android/hyc/monero-android-0.15-build.assert.sig               [OK]
 - v0.15.0.0-android/jonathancross/monero-android-0.15-build.assert.sig     [OK]
 - v0.15.0.0-android/stefanomarty/monero-android-0.15-build.assert.sig      [OK]
 - v0.15.0.0-linux/TheCharlatan/monero-linux-0.15-build.assert.sig          [OK]
 - v0.15.0.0-linux/hyc/monero-linux-0.15-build.assert.sig                   [OK]
 - v0.15.0.0-linux/jonathancross/monero-linux-0.15-build.assert.sig         [OK]
 - v0.15.0.0-linux/stefanomarty/monero-linux-0.15-build.assert.sig          [OK]
 - v0.15.0.0-osx/TheCharlatan/monero-osx-0.15-build.assert.sig              [OK]
 - v0.15.0.0-osx/hyc/monero-osx-0.15-build.assert.sig                       [OK]
 - v0.15.0.0-osx/jonathancross/monero-osx-0.15-build.assert.sig             [OK]
 - v0.15.0.0-win/TheCharlatan/monero-win-0.15-build.assert.sig              [OK]
 - v0.15.0.0-win/hyc/monero-win-0.15-build.assert.sig                       [OK]
 - v0.15.0.0-win/jonathancross/monero-win-0.15-build.assert.sig             [OK]
 - v0.15.0.0-win/stefanomarty/monero-win-0.15-build.assert.sig              [OK]
ERROR: One or more signatures failed verification.
```
 
In the future, we should make this more sophisticated, but this is enough for one PR  :-)
