### PR TITLE
verify-merge.py : fix error in sys.stderr.write

### DIFF
--- a/verify-merge.py
+++ b/verify-merge.py
@@ -59,7 +59,7 @@ def verify():
                 if 'sdk' in assert_file_contents[i]:
                     continue
                 if assert_file_contents[i] != first_file_contents[i]:
-                    sys.stderr.write('ERROR: Found conflicting contents on line:', i)
+                    sys.stderr.write('ERROR: Found conflicting contents on line: ' + str(i) + ' of file ')
                     sys.stderr.write(assert_file + ':\n' + assert_file_contents[i])
                     sys.stderr.write(first_file + ':\n' + first_file_contents[i])
                     exit(1)


### PR DESCRIPTION
Fixes use of sys.stderr.write:

```
Traceback (most recent call last):
  File "./verify-merge.py", line 109, in <module>
    main()
  File "./verify-merge.py", line 101, in main
    verify()
  File "./verify-merge.py", line 62, in verify
    sys.stderr.write('ERROR: Found conflicting contents on line:', i)
TypeError: write() takes exactly one argument (2 given)
```

Issue discovered while verifying #37